### PR TITLE
add react native check and short circuit logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ Each function you pass to `composeProps` will be called with `(state, props)` an
 
 `composeProps` calls each passed function from left to right(top to bottom) with the same `state` but with the previous functions returned 'props' object as the new `props`.
 
+#####React Native
+At Craftsy we are using this library both on the web an on ios/android using [React Native](https://facebook.github.io/react-native/).
+
+For this reason we use the `setStateTypes` and `setPropTypes` checkers as fail safes that return `null` from `composeProps` when there is a state/prop error.
+
+####setStateTypes / setPropTypes - object value checkers
+These can and probably should be used for your input contract to `composeProps` and your output contract. They are based off [react propTypes](https://facebook.github.io/react/docs/reusable-components.html#prop-validation) and require the same method signature, `function(props, propName, componentName)`.
+
+**NOTE:** These object value checkers will short circuit if an error is found, `console.warn()` the error, and finally return null.
 
 ####Example
 example use with [react-redux](https://github.com/rackt/react-redux) `connect`:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "./dist/composeProps.js",
   "scripts": {
     "build": "./node_modules/.bin/babel ./src/composeProps.js --out-file ./dist/composeProps.js",
+    "prepublish": "npm run build",
     "test": "node_modules/.bin/standard && BABEL_ENV=commonjs mocha --compilers js:babel-register tests/tests.spec.js"
   },
   "repository": {

--- a/src/composeProps.js
+++ b/src/composeProps.js
@@ -38,25 +38,31 @@ export function mapPropsOnChange (dependentPropKeys, propsMapper) {
   }
 }
 
-function checkObjectTypes (types, obj, viewModelName) {
-  if (process.env.NODE_ENV !== 'production') {
-    Object.keys(types).forEach((key) => {
+export function hasObjectTypeError (types, obj, viewModelName = 'hasObjectTypeError Checker') {
+  // Always perform checks when running on react native, and short circuit if checks fail
+  if ((typeof navigator !== 'undefined' && navigator.product === 'ReactNative') ||
+  (typeof process === 'undefined' || process.env.NODE_ENV !== 'production')) {
+    const keys = Object.keys(types)
+    for (let i in keys) {
+      const key = keys[i]
       const message = types[key](obj, key, viewModelName)
       if (message) {
-        console.error(message)
+        console.warn(message)
+        return true
       }
-    })
+    }
   }
+  return false
 }
 
 /**
  * [setPropTypes method type description]
  * (c -> d) -> (a -> b -> b)
  */
-export function setPropTypes (propTypes, viewModelName) {
+export function setPropTypes (propTypes, viewModelName = 'setPropTypes Checker') {
   return function setPropTypesMethod (state, props) {
-    checkObjectTypes(propTypes, props, viewModelName)
-    return props
+    // return null if checker found errors
+    return hasObjectTypeError(propTypes, props, viewModelName) ? null : props
   }
 }
 
@@ -64,10 +70,9 @@ export function setPropTypes (propTypes, viewModelName) {
  * [setStateTypes method type description]
  * (c -> d) -> (a -> b -> b)
  */
-export function setStateTypes (stateTypes, viewModelName) {
+export function setStateTypes (stateTypes, viewModelName = 'setStateTypes Checker') {
   return function setStateTypesMethod (state, props) {
-    checkObjectTypes(stateTypes, state, viewModelName)
-    return props
+    return hasObjectTypeError(stateTypes, state, viewModelName) ? null : props
   }
 }
 
@@ -79,6 +84,8 @@ export function composeProps (...funcs) {
   return function composePropsMethod (state, props) {
     props = props || {}
     return funcs.reduce((accProps, func) => {
+      // Short circuit if accProps are null, React Native helper
+      if (accProps === null) return null
       return func(state, accProps)
     }, props)
   }

--- a/src/composeProps.js
+++ b/src/composeProps.js
@@ -39,18 +39,17 @@ export function mapPropsOnChange (dependentPropKeys, propsMapper) {
 }
 
 export function hasObjectTypeError (types, obj, viewModelName = 'hasObjectTypeError Checker') {
-  // Always perform checks when running on react native, and short circuit if checks fail
+  // Always perform checks when running on react native
   if ((typeof navigator !== 'undefined' && navigator.product === 'ReactNative') ||
   (typeof process === 'undefined' || process.env.NODE_ENV !== 'production')) {
-    const keys = Object.keys(types)
-    for (let i in keys) {
-      const key = keys[i]
+    return Object.keys(types).reduce((acc, key) => {
       const message = types[key](obj, key, viewModelName)
       if (message) {
         console.warn(message)
         return true
       }
-    }
+      return acc || false
+    }, false)
   }
   return false
 }

--- a/tests/tests.spec.js
+++ b/tests/tests.spec.js
@@ -1,6 +1,6 @@
 /* global describe, it, afterEach, beforeEach */
 import {expect} from 'chai'
-import {mapStateToProps, mapPropsOnChange, setPropTypes, setStateTypes, composeProps} from '../src/composeProps.js'
+import {mapStateToProps, mapPropsOnChange, hasObjectTypeError, setPropTypes, setStateTypes, composeProps} from '../src/composeProps.js'
 import {PropTypes} from 'react'
 
 describe('compose-props', () => {
@@ -72,86 +72,122 @@ describe('compose-props', () => {
     })
   })
 
-  describe('setPropTypes()', () => {
-    let oldConsoleError
+  describe('hasObjectTypeError() - used by setStateTypes and setPropTypes', () => {
+    let oldConsoleWarn
     let testError = 'no errors'
-    const testText = 'setPropTypesTest'
-
     beforeEach(() => {
-      // mocking console.error for test purposes... gross...
-      oldConsoleError = console.error
-      console.error = (err) => {
+      // mocking console.warn for test purposes... gross...
+      oldConsoleWarn = console.warn
+      console.warn = (err) => {
         testError = err
       }
     })
     afterEach(() => {
-      console.error = oldConsoleError
+      console.warn = oldConsoleWarn
       testError = 'no errors'
     })
 
-    const initState = {}
-    const initProps = {a: 1, b: {c: 2}}
-    const testPropTypes = {
+    const dataObject = {a: 1, b: {c: 2}}
+    const testObjectTypes = {
       a: PropTypes.number.isRequired,
       b: PropTypes.shape({c: PropTypes.number.isRequired}).isRequired
     }
 
-    it('should return props', () => {
-      const statePropsFunc = setPropTypes({}, testText)
-      const outputProps = statePropsFunc(initState, initProps)
-      expect(outputProps).to.deep.equal(initProps)
+    it('should return false when there are no error', () => {
+      const hasErrors = hasObjectTypeError({}, dataObject)
+      expect(hasErrors).to.deep.equal(false)
     })
-    it('should not error with passing propTypes', () => {
-      const statePropsFunc = setPropTypes(testPropTypes, testText)
-      statePropsFunc(initState, initProps)
+    it('should return false and not console.warn any errors with passing propTypes', () => {
+      const hasErrors = hasObjectTypeError(testObjectTypes, dataObject)
+      expect(hasErrors).to.deep.equal(false)
       expect(testError).to.equal('no errors')
     })
-    it('should error when there are errors in propTypes', () => {
-      const badProps = {}
-      const statePropsFunc = setPropTypes(testPropTypes, testText)
-      statePropsFunc(initState, badProps)
+    it('should return true and console.warn errors when there are errors in propTypes', () => {
+      const hasErrors = hasObjectTypeError(testObjectTypes, {})
+      expect(hasErrors).to.deep.equal(true)
       expect(testError).to.not.equal('no errors')
+    })
+
+    describe('hasObjectTypeError tests which NODE_ENV environment', () => {
+      let oldEnv
+      beforeEach(() => {
+        oldEnv = process.env.NODE_ENV
+      })
+      afterEach(() => {
+        process.env.NODE_ENV = oldEnv
+      })
+      it('should return false when NODE_ENV is \'production\'', () => {
+        process.env.NODE_ENV = 'production'
+        const hasErrors = hasObjectTypeError(testObjectTypes, {})
+        expect(hasErrors).to.deep.equal(false)
+      })
+    })
+    describe('hasObjectTypeError tests if running in React Native environment', () => {
+      let oldEnv
+      beforeEach(() => {
+        oldEnv = process.env.NODE_ENV
+        GLOBAL.navigator = {}
+        Object.defineProperty(GLOBAL.navigator, 'product', {value: 'ReactNative'})
+      })
+      afterEach(() => {
+        process.env.NODE_ENV = oldEnv
+        delete GLOBAL.navigator
+      })
+      it('should run when in React Native, even when NODE_ENV is \'production\'', () => {
+        process.env.NODE_ENV = 'production'
+        const hasErrors = hasObjectTypeError(testObjectTypes, {})
+        expect(hasErrors).to.deep.equal(true)
+      })
+    })
+  })
+
+  describe('setPropTypes()', () => {
+    let oldConsoleWarn
+    beforeEach(() => {
+      // mocking console.warn for test purposes... gross...
+      oldConsoleWarn = console.warn
+      console.warn = () => {}
+    })
+    afterEach(() => {
+      console.warn = oldConsoleWarn
+    })
+    it('should return props when there are no errors', () => {
+      const initProps = {a: 1}
+      const statePropsFunc = setPropTypes({})
+      const outputProps = statePropsFunc({}, initProps)
+      expect(outputProps).to.deep.equal(initProps)
+    })
+    it('should return null when there are errors', () => {
+      const initProps = {a: '1'}
+      const testObjectTypes = { a: PropTypes.number.isRequired }
+      const statePropsFunc = setPropTypes(testObjectTypes)
+      const outputProps = statePropsFunc({}, initProps)
+      expect(outputProps).to.equal(null)
     })
   })
 
   describe('setStateTypes()', () => {
-    let oldConsoleError
-    let testError = 'no errors'
-    const testText = 'setStateTypesTest'
-
+    let oldConsoleWarn
     beforeEach(() => {
-      // mocking console.error for test purposes... gross...
-      oldConsoleError = console.error
-      console.error = (err) => {
-        testError = err
-      }
+      // mocking console.warn for test purposes... gross...
+      oldConsoleWarn = console.warn
+      console.warn = () => {}
     })
     afterEach(() => {
-      console.error = oldConsoleError
-      testError = 'no errors'
+      console.warn = oldConsoleWarn
     })
-
-    const initState = {set: [{ id: 1 }, { id: 2 }]}
-    const initProps = {}
-    const testStateProps = {
-      set: PropTypes.arrayOf(PropTypes.shape({id: PropTypes.number.isRequired})).isRequired
-    }
-
-    it('should return props', () => {
-      const statePropsFunc = setStateTypes({}, testText)
-      const outputProps = statePropsFunc(initState, initProps)
+    it('should return props when there are no errors', () => {
+      const initProps = {a: 1}
+      const statePropsFunc = setStateTypes({})
+      const outputProps = statePropsFunc({}, initProps)
       expect(outputProps).to.deep.equal(initProps)
     })
-    it('should not error with passing stateTypes', () => {
-      const statePropsFunc = setStateTypes(testStateProps, testText)
-      statePropsFunc(initState, initProps)
-      expect(testError).to.equal('no errors')
-    })
-    it('should error when there are errors in stateTypes', () => {
-      const badState = {}
-      const statePropsFunc = setStateTypes(testStateProps, testText)
-      statePropsFunc(badState, initProps)
-      expect(testError).to.not.equal('no errors')
+    it('should return null when there are errors', () => {
+      const initState = {a: '1'}
+      const testObjectTypes = { a: PropTypes.number.isRequired }
+      const statePropsFunc = setPropTypes(testObjectTypes)
+      const outputProps = statePropsFunc(initState, {})
+      expect(outputProps).to.equal(null)
     })
   })
 
@@ -190,18 +226,42 @@ describe('compose-props', () => {
     })
 
     describe('works with other compose-props methods', () => {
-      let oldConsoleError
+      let oldConsoleWarn
       let testError = 'no errors'
       beforeEach(() => {
-        // mocking console.error for test purposes... gross...
-        oldConsoleError = console.error
-        console.error = (err) => {
+        // mocking console.warn for test purposes... gross...
+        oldConsoleWarn = console.warn
+        console.warn = (err) => {
           testError = err
         }
       })
       afterEach(() => {
-        console.error = oldConsoleError
+        console.warn = oldConsoleWarn
         testError = 'no errors'
+      })
+
+      it('should \'short circuit\' when a composed function returns null', () => {
+        const testStateProps = { set: PropTypes.arrayOf(PropTypes.number.isRequired).isRequired }
+        let count = 0
+        const initState = {set: ['a', 'b']}
+
+        const statePropsFunc = composeProps(
+          (s, p) => {
+            count += 1
+            return p
+          },
+          setStateTypes(testStateProps, 'compose setStateTypes'),
+          (s, p) => {
+            count += 1
+            return p
+          }
+        )
+
+        expect(count).to.equal(0)
+        const firstRunProps = statePropsFunc(initState, initProps)
+        expect(testError).to.not.equal('no errors')
+        expect(count).to.equal(1)
+        expect(firstRunProps).to.equal(null)
       })
 
       it('should work with mapStateToProps, setPropTypes, setStateTypes, and mapPropsOnChange', () => {
@@ -242,10 +302,10 @@ describe('compose-props', () => {
 
         const expectOutProps = {a: 1, d: 4, e: 5}
         const firstRunProps = statePropsFunc(initState, initProps)
+        expect(testError).to.equal('no errors')
         expect(calledComposeCount).to.equal(1)
         expect(calledOnChangeCount).to.equal(1)
         expect(firstRunProps).to.deep.equal(expectOutProps)
-        expect(testError).to.equal('no errors')
 
         const secondRunProps = statePropsFunc(initState, initProps)
         expect(calledComposeCount).to.equal(2)


### PR DESCRIPTION
- when the environment is running in `React Native` both `setPropTypes` and `setStateTypes` will continue to run
- add a 'short circuit' for when `composeProps` receives a `null` from a compose function
