### PR TITLE
impliment empty object return with composeProps and type errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,17 @@ Each function you pass to `composeProps` will be called with `(state, props)` an
 
 `composeProps` calls each passed function from left to right(top to bottom) with the same `state` but with the previous functions returned 'props' object as the new `props`.
 
-#####React Native
-At Craftsy we are using this library both on the web an on ios/android using [React Native](https://facebook.github.io/react-native/).
+**NOTE** If the value `null` is returned from any of the composed functions, the `composeProps` will short circuit, and return an empty object`{}`.
 
-For this reason we use the `setStateTypes` and `setPropTypes` checkers as fail safes that return `null` from `composeProps` when there is a state/prop error.
+#####React Native
+At Craftsy we are using this library both on the web and on ios/android with [React Native](https://facebook.github.io/react-native/).
+
+For this reason we use the `setStateTypes` and `setPropTypes` checkers as fail safes that return and empty object`{}` from `composeProps` when there is a state/prop type error.
 
 ####setStateTypes / setPropTypes - object value checkers
 These can and probably should be used for your input contract to `composeProps` and your output contract. They are based off [react propTypes](https://facebook.github.io/react/docs/reusable-components.html#prop-validation) and require the same method signature, `function(props, propName, componentName)`.
 
-**NOTE:** These object value checkers will short circuit if an error is found, `console.warn()` the error, and finally return null.
+**NOTE:** These object value checkers will short circuit if an error is found, `console.warn()` the error, and finally return `null`.
 
 ####Example
 example use with [react-redux](https://github.com/rackt/react-redux) `connect`:

--- a/src/composeProps.js
+++ b/src/composeProps.js
@@ -82,10 +82,11 @@ export function setStateTypes (stateTypes, viewModelName = 'setStateTypes Checke
 export function composeProps (...funcs) {
   return function composePropsMethod (state, props) {
     props = props || {}
-    return funcs.reduce((accProps, func) => {
+    const composedProps = funcs.reduce((accProps, func) => {
       // Short circuit if accProps are null, React Native helper
       if (accProps === null) return null
       return func(state, accProps)
     }, props)
+    return composedProps || {}
   }
 }

--- a/tests/tests.spec.js
+++ b/tests/tests.spec.js
@@ -240,7 +240,7 @@ describe('compose-props', () => {
         testError = 'no errors'
       })
 
-      it('should \'short circuit\' when a composed function returns null', () => {
+      it('should \'short circuit\' when a composed function returns null, and return an empty object({})', () => {
         const testStateProps = { set: PropTypes.arrayOf(PropTypes.number.isRequired).isRequired }
         let count = 0
         const initState = {set: ['a', 'b']}
@@ -261,7 +261,7 @@ describe('compose-props', () => {
         const firstRunProps = statePropsFunc(initState, initProps)
         expect(testError).to.not.equal('no errors')
         expect(count).to.equal(1)
-        expect(firstRunProps).to.equal(null)
+        expect(firstRunProps).to.deep.equal({})
       })
 
       it('should work with mapStateToProps, setPropTypes, setStateTypes, and mapPropsOnChange', () => {


### PR DESCRIPTION
in `composeProps` if a null is returned from any composed function, short circuit and return an empty object`{}`.
